### PR TITLE
Fix up project references to point to the RudeBuild-generated projects

### DIFF
--- a/src/RudeBuild/ProjectReaderWriter.cs
+++ b/src/RudeBuild/ProjectReaderWriter.cs
@@ -173,6 +173,18 @@ namespace RudeBuild
             }
         }
 
+        private static void FixupProjectReferences(XDocument projectDocument, XNamespace ns, string fileNamePrefix)
+        {
+            foreach (XElement itemProjectReferenceElement in projectDocument.Descendants(ns + "ProjectReference"))
+            {
+                var includeAttribute = itemProjectReferenceElement.Attribute("Include");
+                if (null != includeAttribute)
+                {
+                    includeAttribute.Value = fileNamePrefix + includeAttribute.Value;
+                }
+            }
+        }
+
         private XElement GetProjectElement(string projectFileName, XNamespace ns, XDocument projectDocument)
         {
             XElement projectElement = projectDocument.Element(ns + "Project");
@@ -344,6 +356,8 @@ namespace RudeBuild
                 {
                     SetBigObjCompilerFlag(projectDocument, ns);
                 }
+
+                FixupProjectReferences(projectDocument, ns, _settings.GlobalSettings.FileNamePrefix);
 
                 ReadWriteFilters(projectFileName, projectConfig, merger);
             }


### PR DESCRIPTION
This modification makes sure that `<ProjectReference Include="PROJECT_NAME.vcxproj">` is set to the RudeBuild-generated one. This field is used, among other things, for features like "Use Library Dependency Inputs".
