### PR TITLE
Fix non-lowercase source files not being merged

### DIFF
--- a/src/RudeBuild/Settings.cs
+++ b/src/RudeBuild/Settings.cs
@@ -77,7 +77,7 @@ namespace RudeBuild
 
 		public bool IsValidCppFileName(string fileName)
 		{
-			string extension = Path.GetExtension(fileName);
+			string extension = Path.GetExtension(fileName).ToLower();
 			return extension == ".cpp" || extension == ".cxx" || extension == ".c" || extension == ".cc";
 		}
 	}

--- a/src/RudeBuild/UnityFileMerger.cs
+++ b/src/RudeBuild/UnityFileMerger.cs
@@ -144,7 +144,7 @@ namespace RudeBuild
 
                 // Get the Unity file for the file extension. We separate .c and .cpp files because this is what makes
                 // Visual Studio choose if it should do a C-only or a C++ compile. There are subtle compiler differences.
-                string fileExtension = Path.GetExtension(cppFileName);
+                string fileExtension = Path.GetExtension(cppFileName).ToLower();
                 UnityFile unityFile;
                 if (!_unityFiles.TryGetValue(fileExtension, out unityFile))
                 {


### PR DESCRIPTION
Fixes 2 cases where files were not being merged correctly:
- upper-case extensions like .CPP or .C would not be merged as they were not considered "valid cpp file names". Fixed in Settings.cs.
- once the above was fixed, .cpp and .CPP files would be merged into separate unity files. Fixed in UnityFileMerger.cs
