### PR TITLE
Fix Wix Setup not building

### DIFF
--- a/src/RudeBuildWixSetup/Program.cs
+++ b/src/RudeBuildWixSetup/Program.cs
@@ -54,7 +54,6 @@ class Script
                         new File(@"LICENSE.rtf"),
                         new File(@"LICENSE.txt"),
                         new File(@"README.txt"),
-                        new Dir(@"en-US", new File(@"en-US\RudeBuild.resources.dll"))
                     }
                 )
             },


### PR DESCRIPTION
If you build from a clean repo (or run 'git clean -xdf'), the RudeBuildWixSetup project doesn't build. It seems this is due to a stale dependency on "en-US\RudeBuild.resources.dll". Simply removing this dependency seems to do the trick of fixing the build.
