### PR TITLE
Add "generateOnly" parameter to generate solution, project, and cache…

### DIFF
--- a/src/RudeBuild/BuildOptions.cs
+++ b/src/RudeBuild/BuildOptions.cs
@@ -4,7 +4,7 @@ using CommandLineParser.Validation;
 
 namespace RudeBuild
 {
-	[ArgumentGroupCertification("rebuild,clean", EArgumentGroupCondition.OneOreNoneUsed)]
+	[ArgumentGroupCertification("rebuild,generateOnly,clean", EArgumentGroupCondition.OneOreNoneUsed)]
     public class BuildOptions
     {
         [FileArgument('s', "solution", FileMustExist = true, Description = "FileName of the solution to build.", Optional = false)]
@@ -15,6 +15,8 @@ namespace RudeBuild
         public string Project;
         [SwitchArgument('r', "rebuild", false, Description = "Does a full rebuild of the build target")]
         public bool Rebuild;
+        [SwitchArgument('g', "generateOnly", false, Description = "Generates the RudeBuild solution, project and intermediate cache files for the build target, but does not proceed to build the target.")]
+        public bool GenerateOnly;
         [SwitchArgument('l', "clean", false, Description = "Cleans the solution. Also deletes all RudeBuild-generated intermediate cache files.")]
         public bool Clean;
         [SwitchArgument('h', "cleanCache", false, Description = "Deletes all RudeBuild-generated intermediate cache files for the given solution, i.e. the cached unity .cpp files and the generated solution and project files.")]
@@ -22,7 +24,7 @@ namespace RudeBuild
 
         public bool ShouldForceWriteCachedFiles()
         {
-            return Rebuild || Clean || CleanCache;
+            return Rebuild || GenerateOnly || Clean || CleanCache;
         }
     }
 }

--- a/src/RudeBuildConsole/Program.cs
+++ b/src/RudeBuildConsole/Program.cs
@@ -97,15 +97,18 @@ namespace RudeBuildConsole
                     projectReaderWriter.ReadWrite(solutionInfo);
                     settings.SolutionSettings.UpdateAndSave(settings, solutionInfo);
 
-                    var processLauncher = new ProcessLauncher(settings);
-                    Console.CancelKeyPress += delegate(object sender, ConsoleCancelEventArgs cancelArgs)
+                    if (!options.GenerateOnly)
                     {
-                        _output.WriteLine("Stopping build...");
-                        processLauncher.Stop();
-                        cancelArgs.Cancel = true;
-                    };
+                        var processLauncher = new ProcessLauncher(settings);
+                        Console.CancelKeyPress += delegate (object sender, ConsoleCancelEventArgs cancelArgs)
+                        {
+                            _output.WriteLine("Stopping build...");
+                            processLauncher.Stop();
+                            cancelArgs.Cancel = true;
+                        };
 
-                    exitCode = processLauncher.Run(solutionInfo);
+                        exitCode = processLauncher.Run(solutionInfo);
+                    }
                 }
 
                 stopwatch.Stop();


### PR DESCRIPTION
… files for target, but doesn't build the target

This is useful for scripting or when you wish to work directly within a RudeBuild-generated solution.

The reason I added this flag is to get around the problem of not being able to start debugging (F5) in VS when RudeBuilding Durango projects. What we do is we work in the RudeBuild-generated version of the sln, and when we need to refresh it (say after synching, adding/removing files, modifying files so that they don't get added to a unity file, etc.), we run a little script that invokes RudeBuildConsole with this new flag to simply re-generate. VS detects the changes and we simply reload the sln and go.
