### PR TITLE
Fixed project reference path

### DIFF
--- a/src/RudeBuild/ProjectReaderWriter.cs
+++ b/src/RudeBuild/ProjectReaderWriter.cs
@@ -173,14 +173,14 @@ namespace RudeBuild
             }
         }
 
-        private static void FixupProjectReferences(XDocument projectDocument, XNamespace ns, string fileNamePrefix)
+        private static void FixupProjectReferences(XDocument projectDocument, XNamespace ns, Settings settings)
         {
             foreach (XElement itemProjectReferenceElement in projectDocument.Descendants(ns + "ProjectReference"))
             {
                 var includeAttribute = itemProjectReferenceElement.Attribute("Include");
                 if (null != includeAttribute)
                 {
-                    includeAttribute.Value = fileNamePrefix + includeAttribute.Value;
+                    includeAttribute.Value = settings.ModifyFileName(includeAttribute.Value);
                 }
             }
         }
@@ -357,7 +357,7 @@ namespace RudeBuild
                     SetBigObjCompilerFlag(projectDocument, ns);
                 }
 
-                FixupProjectReferences(projectDocument, ns, _settings.GlobalSettings.FileNamePrefix);
+                FixupProjectReferences(projectDocument, ns, _settings);
 
                 ReadWriteFilters(projectFileName, projectConfig, merger);
             }


### PR DESCRIPTION
Instead of appending directly the prefix (e.g. "RudeBuild_") to project reference, I'm using 
Settings.ModifyFileName to append correctly the prefix. 

So, if includeAttribute.Value contains : "..\StatisticsDisplay\StatisticsDisplay.vcxproj"

Before modification : "RudeBuild_..\StatisticsDisplay\StatisticsDisplay.vcxproj" 
After modification : "..\StatisticsDisplay\RudeBuild_StatisticsDisplay.vcxproj"

Let me know if it is correct or if it should be done otherwise.
