### PR TITLE
Save/load GlobalSettings in user's AppData directory in a RudeBuild s…

### DIFF
--- a/src/RudeBuild/GlobalSetings.cs
+++ b/src/RudeBuild/GlobalSetings.cs
@@ -23,8 +23,8 @@ namespace RudeBuild
         {
             get
             {
-                string installationPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-                string configFilePath = Path.Combine(installationPath, ConfigFileName);
+                string appDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "RudeBuild");
+                string configFilePath = Path.Combine(appDataPath, ConfigFileName);
                 return configFilePath;
             }
         }
@@ -113,8 +113,18 @@ namespace RudeBuild
             }
         }
 
+        private void CreateConfigFileDirectoryIfNotExists()
+        {
+            if (!File.Exists(ConfigFilePath))
+            {
+                var directory = System.IO.Path.GetDirectoryName(ConfigFilePath);
+                System.IO.Directory.CreateDirectory(directory);
+            }
+        }
+
         private void SaveInternal()
         {
+            CreateConfigFileDirectoryIfNotExists();
             using (TextWriter textWriter = new StreamWriter(ConfigFilePath))
             {
                 var serializer = new XmlSerializer(typeof(GlobalSettings));


### PR DESCRIPTION
…ubdirectory

- Fixes issues with requiring access rights to installation directory (C:\Program Files...) when saving global settings
- Makes it so that all instances of RudeBuild use the same settings files, for e.g. the VSIX-installed version would use a different settings files vs. the add-in versions.